### PR TITLE
Bugfix: when the selected post disappears, fallback to a real post, not a container element

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bluesky-shortcuts",
-    "version": "1.8.2",
+    "version": "1.8.3",
     "description": "Adds keyboard shortcuts to bsky.app",
     "scripts": {
         "build": "npm run build:chrome:prod && npm run build:firefox:prod",

--- a/src/content-scripts/main.js
+++ b/src/content-scripts/main.js
@@ -415,8 +415,12 @@ class BlueSkyShortcuts {
                     // Filter: ignore svg effects
                     let did_remove_post = [...mutation.removedNodes].some(n => n.contains(toggledPost))
                     if (did_remove_post) {
+                        // Select the previous sibling's post as the current post.
+                        // (It is not guaranteed to be mutation.previousSibling, but should overlap it.)
+                        const visiblePosts = DOMUtils.findVisiblePosts();
+                        const previousPost = DOMUtils.findPostByCurrentPosition(visiblePosts, mutation.previousSibling);
                         this.appState.updateState({
-                            currentPost: mutation.previousSibling,
+                            currentPost: previousPost,
                             currentLinkIndex: -1
                         });
                         return


### PR DESCRIPTION
This fixes a bug where deleting a saved post using keyboard shortcuts would cause the currentPost element to be a container element and not what bluesky-shortcuts considers to be a post, causing undefined behavior. 

This fixes the bug by routing this case through the existing "find closest" method, to select the real post overlapping the selected container.